### PR TITLE
Zaai convergence failing because of test on suite level not being cohesive with current zerg params - EPO-241

### DIFF
--- a/suite.yaml
+++ b/suite.yaml
@@ -29,11 +29,11 @@ tests:
           """Placeholder test that always return True"""
           
           if zerg_state:
-            zerg_benchmark_name = zerg_state.get("benchmark name").get("value")
-            print(f"Placeholder Unit Test for benchmark name: {zerg_benchmark_name}")
+            zerg_considerations = zerg_state.get("considerations").get("value")
+            print(f"Placeholder Zerg considerations: {zerg_considerations}")
 
           else:
-            print(f"NO ZERG STATE PROVIDED - Placeholder Unit Test for benchmark")
+            print(f"NO ZERG STATE PROVIDED - Placeholder Unit Test for list of considerations of this suite")
 
           return True
 


### PR DESCRIPTION
The suite placeholder test was always failling, causing Zerg to be stuck and not make any noticeable changes to the generated code.

It was failing because benchmark_name was no longer present in the agent state, causing it to fail and short circuit